### PR TITLE
Bugfix #115 verbose mode hk98

### DIFF
--- a/hidrokit/contrib/taruma/hk98.py
+++ b/hidrokit/contrib/taruma/hk98.py
@@ -27,14 +27,15 @@ def summary_station(dataset, column, ufunc, ufunc_col, n_days='MS'):
     )
 
 
-def summary_all(dataset, ufunc, ufunc_col, columns=None, n_days='MS'):
+def summary_all(dataset, ufunc, ufunc_col, columns=None, n_days='MS', verbose=False):
     res = []
 
     columns = columns if columns is not None else list(dataset.columns)
     columns = columns if isinstance(columns, (list, tuple)) else [columns]
 
     for column in columns:
-        print('PROCESSING:', column)
+        if verbose:
+            print('PROCESSING:', column)
         res.append(
             summary_station(dataset, column, ufunc, ufunc_col, n_days=n_days)
         )


### PR DESCRIPTION
### Ringkasan _Pull Request_

Perbaikan dan penambahan argumen `verbose` untuk fungsi `.contrib.taruma.hk98.summary_all(...)` untuk tidak menampilkan saat proses perekapan. 

### Perbaikan/Fitur

close #115 

### Penggunaan

[manual #98 v1.0.1](https://gist.github.com/taruma/aca7f90c8fbb0034587809883d0d9e92)
