### PR TITLE
Fitur #162 Pembaruan fungsi read_workbook

### DIFF
--- a/hidrokit/contrib/taruma/hk88.py
+++ b/hidrokit/contrib/taruma/hk88.py
@@ -51,16 +51,25 @@ def _data_from_sheet(df, station_name, as_df=True):
         return frames
 
 
-def read_workbook(io, stations, as_df=True):
-    """Read dataset from single file based on stations"""
+def read_workbook(io, stations=None, ignore_str='_', as_df=True):
+    """Read dataset from workbook"""
     excel = pd.ExcelFile(io)
 
-    data = []
+    data = {}
+    sheet_names = excel.sheet_names
+    if stations is None:
+        stations = []
+        for sheet in sheet_names:
+            if not sheet.startswith(ignore_str):
+                stations.append(sheet)
+    else:
+        stations = [stations] if isinstance(stations, str) else stations
+
     for station in stations:
-        df = pd.read_excel(excel, sheet_name=station, header=None)
-        data.append(_data_from_sheet(df, station))
+        df = excel.parse(sheet_name=station, header=None)
+        data[station] = _data_from_sheet(df, station)
 
     if as_df:
-        return pd.concat(data, sort=True, axis=1)
+        return pd.concat(data.values(), sort=True, axis=1)
     else:
         return data


### PR DESCRIPTION
### Ringkasan _Pull Request_

Pembaruan fungsi `.contrib.taruma.hk88.read_workbook(...)` sesuai isu #162 yaitu membaca buku excel tanpa perlu mengetahui nama stasiun. Terdapat _breaking changes_ yaitu luaran pada versi 0.3.7 pada saat diberi argumen `as_df=False` berupa `dictionary` sedangkan pada versi sebelumnya berupa `list`. Jadi, akan ada perubahan bagi yang menggunakan fungsi `read_workbook` dengan argumen `as_df=False`. 

### Perbaikan/Fitur

close #162

### Penggunaan

[manual (telah diperbarui)](https://gist.github.com/taruma/6d48b3ec9d601019c15fb5833ae03730)