### PR TITLE
Refactor hk73 (BMKG) nama fungsi dan dokumentasi

### DIFF
--- a/hidrokit/contrib/taruma/deprecated_func.py
+++ b/hidrokit/contrib/taruma/deprecated_func.py
@@ -1,0 +1,39 @@
+"""
+This module contains deprecated functions.
+"""
+
+import warnings
+import functools
+
+
+def deprecated(new_func_name):
+    """
+    Decorator to mark a function as deprecated.
+
+    Parameters:
+    - new_func_name (str): The name of the new function that should be used instead.
+
+    Returns:
+    - wrapper (function): The decorated function.
+
+    Example:
+    @deprecated("new_function")
+    def old_function():
+        pass
+
+    The above example will generate a warning when `old_function` is called,
+    suggesting to use `new_function` instead.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                f"{func.__name__} is deprecated, use {new_func_name} instead",
+                DeprecationWarning,
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/hidrokit/contrib/taruma/hk73.py
+++ b/hidrokit/contrib/taruma/hk73.py
@@ -33,7 +33,7 @@ def read_bmkg_excel(io):
     )
 
 
-def _has_nan_values(dataframe):
+def has_nan_values(dataframe):
     """
     Check if the given dataset contains any NaN values.
 
@@ -46,7 +46,7 @@ def _has_nan_values(dataframe):
     return bool(dataframe.isna().any().any())
 
 
-def _get_missing_data_indices(nan_indicator_vector):
+def get_missing_data_indices(nan_indicator_vector):
     """
     Get the indices of missing data in the given nan_indicator_vector.
 
@@ -61,7 +61,7 @@ def _get_missing_data_indices(nan_indicator_vector):
     )
 
 
-def _get_nan_indices_by_column(dataframe):
+def get_nan_indices_by_column(dataframe):
     """
     Get the indices of missing values (NaN) for each column in a DataFrame.
 
@@ -74,11 +74,11 @@ def _get_nan_indices_by_column(dataframe):
     """
     nan = {}
     for col in dataframe.columns:
-        nan[col] = _get_missing_data_indices(dataframe[col].isna().values).tolist()
+        nan[col] = get_missing_data_indices(dataframe[col].isna().values).tolist()
     return nan
 
 
-def _get_unrecorded_indices(dataframe):
+def get_unrecorded_indices(dataframe):
     """
     Get the indices of unrecorded data in the given dataframe.
 
@@ -93,12 +93,12 @@ def _get_unrecorded_indices(dataframe):
 
     for col in dataframe.columns:
         masking = (dataframe[col] == 8888) | (dataframe[col] == 9999)
-        unrecorded_indices[col] = _get_missing_data_indices(masking.values)
+        unrecorded_indices[col] = get_missing_data_indices(masking.values)
 
     return unrecorded_indices
 
 
-def _get_nan_indices_if_exists(dataframe):
+def get_nan_indices_if_exists(dataframe):
     """
     Returns the indices of NaN values in the given dataframe if NaN values exist.
 
@@ -109,17 +109,17 @@ def _get_nan_indices_if_exists(dataframe):
         dict or None: A dictionary with keys as column names and values as lists of
             indices where missing values occur, or None if no NaN values exist.
     """
-    if _has_nan_values(dataframe):
-        return _get_nan_indices_by_column(dataframe)
+    if has_nan_values(dataframe):
+        return get_nan_indices_by_column(dataframe)
     else:
         return None
 
 
-def _get_columns_with_nan_values(dataframe):
+def get_columns_with_nan_values(dataframe):
     return dataframe.columns[dataframe.isna().any()].tolist()
 
 
-def _group_consecutive_elements(input_list: List) -> List[List]:
+def group_consecutive_elements(input_list: List) -> List[List]:
     """
     Groups consecutive elements in the input list.
 
@@ -143,7 +143,7 @@ def _group_consecutive_elements(input_list: List) -> List[List]:
     return group_list
 
 
-def _format_group_indices(
+def format_group_indices(
     group_list, indices=None, format_date="%Y%m%d", date_range_format="{}-{}"
 ):
     """
@@ -191,39 +191,46 @@ def _read_bmkg(*args, **kwargs):
 
 @deprecated("_has_nan_values")
 def _have_nan(*args, **kwargs):
-    return _has_nan_values(*args, **kwargs)
+    return has_nan_values(*args, **kwargs)
 
 
 @deprecated("_get_missing_data_indices")
-def _get_index1D(*args, **kwargs): # pylint: disable=invalid-name
-    return _get_missing_data_indices(*args, **kwargs)
+def _get_index1D(*args, **kwargs):  # pylint: disable=invalid-name
+    return get_missing_data_indices(*args, **kwargs)
 
 
 @deprecated("_get_nan_indices_by_column")
 def _get_nan(*args, **kwargs):
-    return _get_nan_indices_by_column(*args, **kwargs)
+    return get_nan_indices_by_column(*args, **kwargs)
 
 
 @deprecated("_get_unrecorded_indices")
 def _get_missing(*args, **kwargs):
-    return _get_unrecorded_indices(*args, **kwargs)
+    return get_unrecorded_indices(*args, **kwargs)
 
 
 @deprecated("_get_nan_indices_if_exists")
 def _check_nan(*args, **kwargs):
-    return _get_nan_indices_if_exists(*args, **kwargs)
+    return get_nan_indices_if_exists(*args, **kwargs)
 
 
 @deprecated("_get_columns_with_nan_values")
 def _get_nan_columns(*args, **kwargs):
-    return _get_columns_with_nan_values(*args, **kwargs)
+    return get_columns_with_nan_values(*args, **kwargs)
 
 
 @deprecated("_group_consecutive_elements")
 def _group_as_list(*args, **kwargs):
-    return _group_consecutive_elements(*args, **kwargs)
+    return group_consecutive_elements(*args, **kwargs)
 
 
 @deprecated("_format_group_indices")
-def _group_as_index(*args, **kwargs):
-    return _format_group_indices(*args, **kwargs)
+def _group_as_index(
+    group_list, index=None, date_format="%Y%m%d", format_date="{}-{}"
+):
+    return format_group_indices(
+        group_list,
+        indices=index,
+        format_date=date_format,
+        date_range_format=format_date,
+    )

--- a/hidrokit/contrib/taruma/hk73.py
+++ b/hidrokit/contrib/taruma/hk73.py
@@ -1,5 +1,38 @@
-"""manual:
-https://gist.github.com/taruma/b00880905f297013f046dad95dc2e284"""
+"""
+This module provides functions for reading and analyzing 
+    BMKG (Meteorology, Climatology, and Geophysics Agency) data.
+
+For more information, refer to the manual: 
+    https://gist.github.com/taruma/b00880905f297013f046dad95dc2e284
+
+Functions:
+- read_bmkg_excel(io): Read BMKG data from an Excel file.
+- has_nan_values(dataframe): Check if the given dataset contains any NaN values.
+- get_missing_data_indices(nan_indicator_vector): Get the indices of missing data 
+    in the given nan_indicator_vector.
+- get_nan_indices_by_column(dataframe): Get the indices of missing values (NaN) 
+    for each column in a DataFrame.
+- get_unrecorded_indices(dataframe): Get the indices of unrecorded data in the given dataframe.
+- get_nan_indices_if_exists(dataframe): Returns the indices of NaN values 
+    in the given dataframe if NaN values exist.
+- get_columns_with_nan_values(dataframe): Get the columns with NaN values in the given dataframe.
+- group_consecutive_elements(input_list): Groups consecutive elements in the input list.
+- format_group_indices(group_list, indices=None, format_date="%Y%m%d", date_range_format="{}-{}"): 
+    Formats the group indices based on the given parameters.
+
+Deprecated Functions:
+- _read_bmkg(*args, **kwargs): Deprecated version of read_bmkg_excel.
+- _have_nan(*args, **kwargs): Deprecated version of has_nan_values.
+- _get_index1D(*args, **kwargs): Deprecated version of get_missing_data_indices.
+- _get_nan(*args, **kwargs): Deprecated version of get_nan_indices_by_column.
+- _get_missing(*args, **kwargs): Deprecated version of get_unrecorded_indices.
+- _check_nan(*args, **kwargs): Deprecated version of get_nan_indices_if_exists.
+- _get_nan_columns(*args, **kwargs): Deprecated version of get_columns_with_nan_values.
+- _group_as_list(*args, **kwargs): Deprecated version of group_consecutive_elements.
+- _group_as_index(group_list, index=None, date_format="%Y%m%d", format_date="{}-{}"): 
+    Deprecated version of format_group_indices.
+"""
+
 
 from itertools import groupby
 from operator import itemgetter

--- a/hidrokit/contrib/taruma/hk73.py
+++ b/hidrokit/contrib/taruma/hk73.py
@@ -195,7 +195,7 @@ def _have_nan(*args, **kwargs):
 
 
 @deprecated("_get_missing_data_indices")
-def _get_index1D(*args, **kwargs):
+def _get_index1D(*args, **kwargs): # pylint: disable=invalid-name
     return _get_missing_data_indices(*args, **kwargs)
 
 

--- a/hidrokit/contrib/taruma/hk73.py
+++ b/hidrokit/contrib/taruma/hk73.py
@@ -1,97 +1,229 @@
 """manual:
 https://gist.github.com/taruma/b00880905f297013f046dad95dc2e284"""
 
+from itertools import groupby
+from operator import itemgetter
+from typing import List
 import pandas as pd
 import numpy as np
-from operator import itemgetter
-from itertools import groupby
+from hidrokit.contrib.taruma.deprecated_func import deprecated
 
 
-def _read_bmkg(io):
+def read_bmkg_excel(io):
+    """
+    Read BMKG data from an Excel file.
+
+    Parameters:
+    - io: str or file-like object
+        The file path or file-like object to read the Excel data from.
+
+    Returns:
+    - pandas.DataFrame
+        The data read from the Excel file.
+
+    """
     return pd.read_excel(
-        io, skiprows=8, skipfooter=16, header=0, index_col=0, parse_dates=True,
-        date_parser=lambda x: pd.to_datetime(x, format='%d-%m-%Y')
+        io,
+        skiprows=8,
+        skipfooter=16,
+        header=0,
+        index_col=0,
+        parse_dates=True,
+        date_format="%d-%m-%Y",
     )
 
 
-def _have_nan(dataset):
-    if dataset.isna().any().any():
-        return True
-    else:
-        return False
+def _has_nan_values(dataframe):
+    """
+    Check if the given dataset contains any NaN values.
+
+    Parameters:
+        dataframe (pandas.DataFrame): The dataset to check for NaN values.
+
+    Returns:
+        bool: True if the dataset contains NaN values, False otherwise.
+    """
+    return bool(dataframe.isna().any().any())
 
 
-def _get_index1D(array1D_bool):
-    return np.argwhere(array1D_bool).reshape(-1,)
+def _get_missing_data_indices(nan_indicator_vector):
+    """
+    Get the indices of missing data in the given nan_indicator_vector.
+
+    Parameters:
+        nan_indicator_vector (numpy.ndarray): A boolean array indicating missing data.
+
+    Returns:
+        numpy.ndarray: An array of indices where missing data is present.
+    """
+    return np.argwhere(nan_indicator_vector).reshape(
+        -1,
+    )
 
 
-def _get_nan(dataset):
+def _get_nan_indices_by_column(dataframe):
+    """
+    Get the indices of missing values (NaN) for each column in a DataFrame.
+
+    Parameters:
+        dataframe (pandas.DataFrame): The input DataFrame.
+
+    Returns:
+        dict: A dictionary where the keys are the column names and the values are lists of indices
+            where missing values occur in each column.
+    """
     nan = {}
-
-    for col in dataset.columns:
-        nan[col] = _get_index1D(dataset[col].isna().values).tolist()
-
+    for col in dataframe.columns:
+        nan[col] = _get_missing_data_indices(dataframe[col].isna().values).tolist()
     return nan
 
 
-def _get_missing(dataset):
-    missing = {}
+def _get_unrecorded_indices(dataframe):
+    """
+    Get the indices of unrecorded data in the given dataframe.
 
-    for col in dataset.columns:
-        masking = (dataset[col] == 8888) | (dataset[col] == 9999)
-        missing[col] = _get_index1D(masking.values)
+    Parameters:
+        dataframe (pandas.DataFrame): The input dataframe.
 
-    return missing
+    Returns:
+        dict: A dictionary where the keys are the column names and the values are
+            the indices of unrecorded data in each column.
+    """
+    unrecorded_indices = {}
+
+    for col in dataframe.columns:
+        masking = (dataframe[col] == 8888) | (dataframe[col] == 9999)
+        unrecorded_indices[col] = _get_missing_data_indices(masking.values)
+
+    return unrecorded_indices
 
 
-def _check_nan(dataset):
-    if _have_nan(dataset):
-        return _get_nan(dataset)
+def _get_nan_indices_if_exists(dataframe):
+    """
+    Returns the indices of NaN values in the given dataframe if NaN values exist.
+
+    Parameters:
+        dataframe (pandas.DataFrame): The input dataframe.
+
+    Returns:
+        dict or None: A dictionary with keys as column names and values as lists of
+            indices where missing values occur, or None if no NaN values exist.
+    """
+    if _has_nan_values(dataframe):
+        return _get_nan_indices_by_column(dataframe)
     else:
         return None
 
 
-def _get_nan_columns(dataset):
-    return dataset.columns[dataset.isna().any()].tolist()
+def _get_columns_with_nan_values(dataframe):
+    return dataframe.columns[dataframe.isna().any()].tolist()
 
 
-def _group_as_list(array):
+def _group_consecutive_elements(input_list: List) -> List[List]:
+    """
+    Groups consecutive elements in the input list.
 
+    Args:
+        input_list (List): The list of elements to be grouped.
+
+    Returns:
+        List[List]: A list of lists, where each inner list contains consecutive elements
+            from the input list.
+
+    Example:
+        >>> input_list = [1, 2, 3, 5, 6, 8, 9]
+        >>> _group_consecutive_elements(input_list)
+        [[1, 2, 3], [5, 6], [8, 9]]
+    """
     # based on https://stackoverflow.com/a/15276206
     group_list = []
-    for _, g in groupby(enumerate(array), lambda x: x[0] - x[1]):
+    for _, g in groupby(enumerate(input_list), lambda x: x[0] - x[1]):
         single_list = sorted(list(map(itemgetter(1), g)))
         group_list.append(single_list)
-
     return group_list
 
 
-def _group_as_index(
-    group_list, index=None, date_format='%Y%m%d',
-    format_date='{}-{}'
+def _format_group_indices(
+    group_list, indices=None, format_date="%Y%m%d", date_range_format="{}-{}"
 ):
-    group_index = []
-    date_index = isinstance(index, pd.DatetimeIndex)
+    """
+    Formats the group indices based on the given parameters.
+
+    Args:
+        group_list (list): The list of groups.
+        indices (pd.Index or pd.DatetimeIndex, optional): The indices to format. Defaults to None.
+        format_date (str, optional): The date format string. Defaults to "%Y%m%d".
+        date_range_format (str, optional): The format string for date ranges. Defaults to "{}-{}".
+
+    Returns:
+        list: The formatted group indices.
+    """
+    formatted_indices = []
+    is_date_index = isinstance(indices, pd.DatetimeIndex)
 
     for item in group_list:
         if len(item) == 1:
-            if date_index:
-                group_index.append(index[item[0]].strftime(date_format))
+            if is_date_index:
+                formatted_indices.append(indices[item[0]].strftime(format_date))
             else:
-                group_index.append(index[item[0]])
+                formatted_indices.append(indices[item[0]])
         else:
-            if date_index:
-                group_index.append(
-                    format_date.format(
-                        index[item[0]].strftime(date_format),
-                        index[item[-1]].strftime(date_format)
+            if is_date_index:
+                formatted_indices.append(
+                    date_range_format.format(
+                        indices[item[0]].strftime(format_date),
+                        indices[item[-1]].strftime(format_date),
                     )
                 )
             else:
-                group_index.append(
-                    format_date.format(
-                        index[item[0]], index[item[-1]]
-                    )
+                formatted_indices.append(
+                    date_range_format.format(indices[item[0]], indices[item[-1]])
                 )
 
-    return group_index
+    return formatted_indices
+
+
+# for backward compatibility
+@deprecated("read_bmkg_excel")
+def _read_bmkg(*args, **kwargs):
+    return read_bmkg_excel(*args, **kwargs)
+
+
+@deprecated("_has_nan_values")
+def _have_nan(*args, **kwargs):
+    return _has_nan_values(*args, **kwargs)
+
+
+@deprecated("_get_missing_data_indices")
+def _get_index1D(*args, **kwargs):
+    return _get_missing_data_indices(*args, **kwargs)
+
+
+@deprecated("_get_nan_indices_by_column")
+def _get_nan(*args, **kwargs):
+    return _get_nan_indices_by_column(*args, **kwargs)
+
+
+@deprecated("_get_unrecorded_indices")
+def _get_missing(*args, **kwargs):
+    return _get_unrecorded_indices(*args, **kwargs)
+
+
+@deprecated("_get_nan_indices_if_exists")
+def _check_nan(*args, **kwargs):
+    return _get_nan_indices_if_exists(*args, **kwargs)
+
+
+@deprecated("_get_columns_with_nan_values")
+def _get_nan_columns(*args, **kwargs):
+    return _get_columns_with_nan_values(*args, **kwargs)
+
+
+@deprecated("_group_consecutive_elements")
+def _group_as_list(*args, **kwargs):
+    return _group_consecutive_elements(*args, **kwargs)
+
+
+@deprecated("_format_group_indices")
+def _group_as_index(*args, **kwargs):
+    return _format_group_indices(*args, **kwargs)


### PR DESCRIPTION
### Ringkasan _Pull Request_

Refactor nama fungsi dan menambah dokumentasi untuk memudahkan membaca dan menggunakan fungsi yang tersedia

### Perbaikan/Fitur

close #216 

### Catatan

```
This module provides functions for reading and analyzing 
    BMKG (Meteorology, Climatology, and Geophysics Agency) data.

For more information, refer to the manual: 
    https://gist.github.com/taruma/b00880905f297013f046dad95dc2e284

Functions:
- read_bmkg_excel(io): Read BMKG data from an Excel file.
- has_nan_values(dataframe): Check if the given dataset contains any NaN values.
- get_missing_data_indices(nan_indicator_vector): Get the indices of missing data 
    in the given nan_indicator_vector.
- get_nan_indices_by_column(dataframe): Get the indices of missing values (NaN) 
    for each column in a DataFrame.
- get_unrecorded_indices(dataframe): Get the indices of unrecorded data in the given dataframe.
- get_nan_indices_if_exists(dataframe): Returns the indices of NaN values 
    in the given dataframe if NaN values exist.
- get_columns_with_nan_values(dataframe): Get the columns with NaN values in the given dataframe.
- group_consecutive_elements(input_list): Groups consecutive elements in the input list.
- format_group_indices(group_list, indices=None, format_date="%Y%m%d", date_range_format="{}-{}"): 
    Formats the group indices based on the given parameters.

Deprecated Functions:
- _read_bmkg(*args, **kwargs): Deprecated version of read_bmkg_excel.
- _have_nan(*args, **kwargs): Deprecated version of has_nan_values.
- _get_index1D(*args, **kwargs): Deprecated version of get_missing_data_indices.
- _get_nan(*args, **kwargs): Deprecated version of get_nan_indices_by_column.
- _get_missing(*args, **kwargs): Deprecated version of get_unrecorded_indices.
- _check_nan(*args, **kwargs): Deprecated version of get_nan_indices_if_exists.
- _get_nan_columns(*args, **kwargs): Deprecated version of get_columns_with_nan_values.
- _group_as_list(*args, **kwargs): Deprecated version of group_consecutive_elements.
- _group_as_index(group_list, index=None, date_format="%Y%m%d", format_date="{}-{}"): 
    Deprecated version of format_group_indices.
```