### PR TITLE
Refactor hk43.py

### DIFF
--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -97,16 +97,16 @@ def _get_data_for_year(file_path, year, data_format):
     return reshaped_data["value"].drop(DROP_INDICES).values
 
 
-def _get_data_allyear(io, fmt, aslist=False):
-    list_years = _extract_years_from_excel(io)
+def _get_data_allyear(file_path, data_format, return_as_list=False):
+    list_years = _extract_years_from_excel(file_path)
 
     data_each_year = []
 
     for year in list_years:
-        data = _get_data_for_year(io, year=year, data_format=fmt)
+        data = _get_data_for_year(file_path, year=year, data_format=data_format)
         data_each_year.append(data)
 
-    if aslist:
+    if return_as_list:
         return data_each_year
 
     return np.hstack(data_each_year)
@@ -146,7 +146,7 @@ def read_folder(dataset_path, pattern, fmt, prefix="", invalid=False):
     for counter, file in enumerate(dataset_path.glob(pattern)):
         print(f":: {counter + 1:^4}:\t{file.name:s}")
         station_name = prefix + "_".join(file.stem.split("_")[1:-2])
-        data_each_station = _get_data_allyear(file, fmt=fmt)
+        data_each_station = _get_data_allyear(file, data_format=fmt)
         data_allstation[station_name] = data_each_station
         if invalid:
             data_invalid[station_name] = _check_invalid(data_each_station)

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -4,7 +4,7 @@ https://gist.github.com/taruma/a9dd4ea61db2526853b99600909e9c50"""
 from calendar import isleap
 from collections import defaultdict
 from pathlib import Path
-from typing import List
+from typing import Union, List
 import pandas as pd
 import numpy as np
 from hidrokit.contrib.taruma.utils import deprecated
@@ -64,7 +64,7 @@ def _get_pivot_from_excel(excel_file: str, year: int, data_format: str) -> pd.Da
     return df.iloc[start_row:end_row, :]
 
 
-def _get_data_for_year(file_path, year, data_format):
+def _get_data_for_year(file_path: str, year: int, data_format: str) -> np.ndarray:
     """
     Get data for a specific year from a file and return it as a single vector numpy array.
 
@@ -97,7 +97,28 @@ def _get_data_for_year(file_path, year, data_format):
     return reshaped_data["value"].drop(DROP_INDICES).values
 
 
-def _get_data_allyear(file_path, data_format, return_as_list=False):
+def _get_data_allyear(
+    file_path: Union[str, Path], data_format: str, return_as_list: bool = False
+) -> Union[List[np.ndarray], np.ndarray]:
+    """
+    Get data for all years from a given file.
+
+    Args:
+        file_path (Union[str, Path]): The path to the file.
+        data_format (str): The format of the data.
+        return_as_list (bool, optional): Whether to return the data as a list of arrays. Defaults to False.
+
+    Returns:
+        Union[List[np.ndarray], np.ndarray]: The data for all years.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    file_path = Path(file_path)
+
+    if not file_path.exists():
+        raise FileNotFoundError(f"No such file or directory: '{file_path}'")
+
     list_years = _extract_years_from_excel(file_path)
 
     data_each_year = []

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -84,13 +84,13 @@ def _check_invalid(array, check=np.float):
 def read_folder(dataset_path, pattern, fmt, prefix='', invalid=False):
     dataset_path = Path(dataset_path)
     total_files = len(list(dataset_path.glob(pattern)))
-    print('Found {} file(s)'.format(total_files))
+    print(f'Found {total_files} file(s)')
 
     data_allstation = {}
     data_invalid = {}
 
     for counter, file in enumerate(dataset_path.glob(pattern)):
-        print(':: {:^4}:\t{:s}'.format(counter + 1, file.name))
+        print(f':: {counter + 1:^4}:\t{file.name:s}')
         station_name = prefix + '_'.join(file.stem.split('_')[1:-2])
         data_each_station = _get_data_allyear(file, fmt=fmt)
         data_allstation[station_name] = data_each_station

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -28,7 +28,7 @@ def _extract_years_from_excel(io: str) -> List[int]:
     return sorted(years)
 
 
-def _get_pivot_from_excel(excel_file, year, data_format):
+def _get_pivot_from_excel(excel_file: str, year: int, data_format: str) -> pd.DataFrame:
     """
     Get a pivot table from an Excel file.
 
@@ -134,6 +134,7 @@ def read_folder(dataset_path, pattern, fmt, prefix="", invalid=False):
 @deprecated("_extract_years_from_excel")
 def _get_years(io: str) -> List[int]:
     return _extract_years_from_excel(io)
+
 
 @deprecated("_get_pivot_from_excel")
 def _get_pivot(io, year, fmt):

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -75,7 +75,7 @@ def _have_invalid(array, check):
     return bool(_get_invalid(array, check=check))
 
 
-def _check_invalid(array, check=np.float):
+def _check_invalid(array, check=float):
     if _have_invalid(array, check=check):
         return _get_invalid(array, check=check)
     return None

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -328,10 +328,10 @@ def _get_data_allyear(*args, **kwargs):
 
 
 @deprecated("_get_invalid_elements_indices")
-def _get_invalid(*args, **kwargs):
-    return _get_invalid_elements_indices(*args, **kwargs)
+def _get_invalid(array, check):
+    return _get_invalid_elements_indices(array, validation_func=check)
 
 
 @deprecated("have_invalid")
-def _have_invalid(*args, **kwargs):
-    return have_invalid(*args, **kwargs)
+def _have_invalid(array, check):
+    return have_invalid(array, validation_func=check)

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -1,5 +1,65 @@
-"""manual:
-https://gist.github.com/taruma/a9dd4ea61db2526853b99600909e9c50"""
+"""
+hk43: pamarayan_excel_data_extraction
+This module provides functions for reading and 
+    extracting data from Excel files in a specific format.
+
+Manual:
+https://gist.github.com/taruma/a9dd4ea61db2526853b99600909e9c50
+
+Functions:
+- _extract_years_from_excel(file_path: str) -> List[int]:
+    Get a list of years from an Excel file.
+
+- _get_pivot_from_excel(excel_file: str, year: int, data_format: str) -> pd.DataFrame:
+    Get a pivot table from an Excel file.
+
+- _get_data_for_year(file_path: str, year: int, data_format: str) -> np.ndarray:
+    Get data for a specific year from a file and return it as a single vector numpy array.
+
+- _get_data_all_year(
+    file_path: Union[str, Path], data_format: str, return_as_list: bool = False
+    ) -> Union[List[np.ndarray], np.ndarray]:
+        Get data for all years from a given file.
+
+- _get_invalid_elements_indices(
+    num_array: Any, validation_func: Callable[[Any], Any]
+    ) -> Dict[str, List[int]]:
+        Returns a dictionary containing the indices of invalid elements in the given `num_array`.
+
+- have_invalid(array: List[Any], validation_func: Callable[[Any], Any]) -> bool:
+    Check if the given array has any invalid elements based on the provided validation function.
+
+- _check_invalid(array, validation_func=float):
+    Check if there are any invalid elements in the array.
+
+- read_folder(
+    dataset_path: str,
+    filename_pattern: str,
+    data_format: str,
+    station_name_prefix: str = "",
+    check_for_invalid_data: bool = False
+) -> Union[Dict[str, np.ndarray], Dict[str, np.ndarray], Dict[str, List[int]]]:
+    Read files from a folder and extract data for each station.
+
+Deprecated Functions:
+- _get_years(io: str) -> List[int]:
+    Deprecated. Use _extract_years_from_excel instead.
+
+- _get_pivot(io, year, fmt):
+    Deprecated. Use _get_pivot_from_excel instead.
+
+- _get_data_oneyear(io, year, fmt):
+    Deprecated. Use _get_data_for_year instead.
+
+- _get_data_allyear(*args, **kwargs):
+    Deprecated. Use _get_data_all_year instead.
+
+- _get_invalid(*args, **kwargs):
+    Deprecated. Use _get_invalid_elements_indices instead.
+
+- _have_invalid(*args, **kwargs):
+    Deprecated. Use have_invalid instead.
+"""
 
 from calendar import isleap
 from collections import defaultdict
@@ -211,14 +271,14 @@ def read_folder(
         dataset_path (str): The path to the dataset folder.
         filename_pattern (str): The pattern to match the filenames.
         data_format (str): The format of the data in the files.
-        station_name_prefix (str, optional): The prefix to add to the station names. 
+        station_name_prefix (str, optional): The prefix to add to the station names.
             Defaults to "".
-        check_for_invalid_data (bool, optional): Whether to check for invalid data. 
+        check_for_invalid_data (bool, optional): Whether to check for invalid data.
             Defaults to False.
 
     Returns:
         dict: A dictionary containing the extracted data for each station.
-            If `check_for_invalid_data` is True, 
+            If `check_for_invalid_data` is True,
             it also returns a dictionary of invalid data for each station.
     """
     dataset_path = Path(dataset_path)

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -4,11 +4,22 @@ https://gist.github.com/taruma/a9dd4ea61db2526853b99600909e9c50"""
 from calendar import isleap
 from collections import defaultdict
 from pathlib import Path
+from typing import List
 import pandas as pd
 import numpy as np
+from hidrokit.contrib.taruma.utils import deprecated
 
 
-def _get_years(io):
+def _extract_years_from_excel(io: str) -> List[int]:
+    """
+    Get a list of years from an Excel file.
+
+    Args:
+        io (str): The path to the Excel file.
+
+    Returns:
+        List[int]: A sorted list of years found in the Excel file.
+    """
     excel = pd.ExcelFile(io)
     years = []
     for sheet in excel.sheet_names:
@@ -44,7 +55,7 @@ def _get_data_oneyear(io, year, fmt):
 
 
 def _get_data_allyear(io, fmt, aslist=False):
-    list_years = _get_years(io)
+    list_years = _extract_years_from_excel(io)
 
     data_each_year = []
 
@@ -100,3 +111,7 @@ def read_folder(dataset_path, pattern, fmt, prefix='', invalid=False):
     if invalid:
         return data_allstation, data_invalid
     return data_allstation
+
+@deprecated('_extract_years_from_excel')
+def _get_years(io: str) -> List[int]:
+    return _extract_years_from_excel(io)

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -163,7 +163,7 @@ def _get_invalid_elements_indices(
     return invalid_element_indices
 
 
-def _have_invalid(array: List[Any], validation_func: Callable[[Any], Any]) -> bool:
+def have_invalid(array: List[Any], validation_func: Callable[[Any], Any]) -> bool:
     """
     Check if the given array has any invalid elements based on the provided validation function.
 

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -145,10 +145,10 @@ def _get_invalid_elements_indices(
     - validation_func (function): The validation function to be applied to each element.
 
     Returns:
-    - invalid_element_indices (defaultdict): 
+    - invalid_element_indices (defaultdict):
         A defaultdict object containing the indices of invalid elements.
-        The keys of the dictionary represent the type of invalidity, 
-        such as "NaN" for elements that are NaN, and 
+        The keys of the dictionary represent the type of invalidity,
+        such as "NaN" for elements that are NaN, and
         the values are lists of indices corresponding to each type of invalidity.
     """
     invalid_element_indices: Dict[str, List[int]] = defaultdict(list)
@@ -169,7 +169,7 @@ def have_invalid(array: List[Any], validation_func: Callable[[Any], Any]) -> boo
 
     Args:
         array (list): The array to check for invalid elements.
-        validation_func (function): The validation function used 
+        validation_func (function): The validation function used
             to determine if an element is invalid.
 
     Returns:
@@ -190,7 +190,9 @@ def _check_invalid(array, validation_func=float):
         dict or None: A dictionary with the indices of invalid elements,
             or None if there are no invalid elements.
     """
-    invalid_elements_indices = _get_invalid_elements_indices(array, validation_func=validation_func)
+    invalid_elements_indices = _get_invalid_elements_indices(
+        array, validation_func=validation_func
+    )
     return invalid_elements_indices if invalid_elements_indices is not None else None
 
 
@@ -238,3 +240,8 @@ def _get_data_allyear(*args, **kwargs):
 @deprecated("_get_invalid_elements_indices")
 def _get_invalid(*args, **kwargs):
     return _get_invalid_elements_indices(*args, **kwargs)
+
+
+@deprecated("have_invalid")
+def _have_invalid(*args, **kwargs):
+    return have_invalid(*args, **kwargs)

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -1,11 +1,11 @@
 """manual:
 https://gist.github.com/taruma/a9dd4ea61db2526853b99600909e9c50"""
 
-import pandas as pd
-import numpy as np
 from calendar import isleap
 from collections import defaultdict
 from pathlib import Path
+import pandas as pd
+import numpy as np
 
 
 def _get_years(io):
@@ -40,8 +40,7 @@ def _get_data_oneyear(io, year, fmt):
     data = pivot_table.melt().drop('variable', axis=1)
     if isleap(year):
         return data['value'].drop(_drop_leap).values
-    else:
-        return data['value'].drop(_drop).values
+    return data['value'].drop(_drop).values
 
 
 def _get_data_allyear(io, fmt, aslist=False):

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -106,7 +106,8 @@ def _get_data_allyear(
     Args:
         file_path (Union[str, Path]): The path to the file.
         data_format (str): The format of the data.
-        return_as_list (bool, optional): Whether to return the data as a list of arrays. Defaults to False.
+        return_as_list (bool, optional): Whether to return the data as a list of arrays. 
+            Defaults to False.
 
     Returns:
         Union[List[np.ndarray], np.ndarray]: The data for all years.

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -178,10 +178,20 @@ def _have_invalid(array: List[Any], validation_func: Callable[[Any], Any]) -> bo
     return bool(_get_invalid_elements_indices(array, validation_func=validation_func))
 
 
-def _check_invalid(array, check=float):
-    if _have_invalid(array, validation_func=check):
-        return _get_invalid_elements_indices(array, validation_func=check)
-    return None
+def _check_invalid(array, validation_func=float):
+    """
+    Check if there are any invalid elements in the array.
+
+    Parameters:
+        array (iterable): The array to check.
+        validation_func (callable): The validation function to use.
+
+    Returns:
+        dict or None: A dictionary with the indices of invalid elements,
+            or None if there are no invalid elements.
+    """
+    invalid_elements_indices = _get_invalid_elements_indices(array, validation_func=validation_func)
+    return invalid_elements_indices if invalid_elements_indices is not None else None
 
 
 def read_folder(dataset_path, pattern, fmt, prefix="", invalid=False):

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -163,12 +163,23 @@ def _get_invalid_elements_indices(
     return invalid_element_indices
 
 
-def _have_invalid(array, check):
-    return bool(_get_invalid_elements_indices(array, validation_func=check))
+def _have_invalid(array: List[Any], validation_func: Callable[[Any], Any]) -> bool:
+    """
+    Check if the given array has any invalid elements based on the provided validation function.
+
+    Args:
+        array (list): The array to check for invalid elements.
+        validation_func (function): The validation function used 
+            to determine if an element is invalid.
+
+    Returns:
+        bool: True if the array has any invalid elements, False otherwise.
+    """
+    return bool(_get_invalid_elements_indices(array, validation_func=validation_func))
 
 
 def _check_invalid(array, check=float):
-    if _have_invalid(array, check=check):
+    if _have_invalid(array, validation_func=check):
         return _get_invalid_elements_indices(array, validation_func=check)
     return None
 

--- a/hidrokit/contrib/taruma/hk43.py
+++ b/hidrokit/contrib/taruma/hk43.py
@@ -99,5 +99,4 @@ def read_folder(dataset_path, pattern, fmt, prefix='', invalid=False):
 
     if invalid:
         return data_allstation, data_invalid
-    else:
-        return data_allstation
+    return data_allstation


### PR DESCRIPTION
### Ringkasan _Pull Request_

Refactor hk43 (pamarayan_excel_data_extraction)

### Perbaikan/Fitur

close #238 

### Penggunaan

```
hk43: pamarayan_excel_data_extraction
This module provides functions for reading and 
    extracting data from Excel files in a specific format.

Manual:
https://gist.github.com/taruma/a9dd4ea61db2526853b99600909e9c50

Functions:
- _extract_years_from_excel(file_path: str) -> List[int]:
    Get a list of years from an Excel file.

- _get_pivot_from_excel(excel_file: str, year: int, data_format: str) -> pd.DataFrame:
    Get a pivot table from an Excel file.

- _get_data_for_year(file_path: str, year: int, data_format: str) -> np.ndarray:
    Get data for a specific year from a file and return it as a single vector numpy array.

- _get_data_all_year(
    file_path: Union[str, Path], data_format: str, return_as_list: bool = False
    ) -> Union[List[np.ndarray], np.ndarray]:
        Get data for all years from a given file.

- _get_invalid_elements_indices(
    num_array: Any, validation_func: Callable[[Any], Any]
    ) -> Dict[str, List[int]]:
        Returns a dictionary containing the indices of invalid elements in the given `num_array`.

- have_invalid(array: List[Any], validation_func: Callable[[Any], Any]) -> bool:
    Check if the given array has any invalid elements based on the provided validation function.

- _check_invalid(array, validation_func=float):
    Check if there are any invalid elements in the array.

- read_folder(
    dataset_path: str,
    filename_pattern: str,
    data_format: str,
    station_name_prefix: str = "",
    check_for_invalid_data: bool = False
) -> Union[Dict[str, np.ndarray], Dict[str, np.ndarray], Dict[str, List[int]]]:
    Read files from a folder and extract data for each station.

Deprecated Functions:
- _get_years(io: str) -> List[int]:
    Deprecated. Use _extract_years_from_excel instead.

- _get_pivot(io, year, fmt):
    Deprecated. Use _get_pivot_from_excel instead.

- _get_data_oneyear(io, year, fmt):
    Deprecated. Use _get_data_for_year instead.

- _get_data_allyear(*args, **kwargs):
    Deprecated. Use _get_data_all_year instead.

- _get_invalid(*args, **kwargs):
    Deprecated. Use _get_invalid_elements_indices instead.

- _have_invalid(*args, **kwargs):
    Deprecated. Use have_invalid instead.
```

