### PR TITLE
Refactor hk84

### DIFF
--- a/hidrokit/contrib/taruma/hk73.py
+++ b/hidrokit/contrib/taruma/hk73.py
@@ -149,6 +149,15 @@ def get_nan_indices_if_exists(dataframe):
 
 
 def get_columns_with_nan_values(dataframe):
+    """
+    Returns a list of column names that contain NaN values in the given dataframe.
+
+    Parameters:
+    dataframe (pandas.DataFrame): The input dataframe.
+
+    Returns:
+    list: A list of column names that contain NaN values.
+    """
     return dataframe.columns[dataframe.isna().any()].tolist()
 
 

--- a/hidrokit/contrib/taruma/hk73.py
+++ b/hidrokit/contrib/taruma/hk73.py
@@ -222,42 +222,42 @@ def _read_bmkg(*args, **kwargs):
     return read_bmkg_excel(*args, **kwargs)
 
 
-@deprecated("_has_nan_values")
+@deprecated("has_nan_values")
 def _have_nan(*args, **kwargs):
     return has_nan_values(*args, **kwargs)
 
 
-@deprecated("_get_missing_data_indices")
+@deprecated("get_missing_data_indices")
 def _get_index1D(*args, **kwargs):  # pylint: disable=invalid-name
     return get_missing_data_indices(*args, **kwargs)
 
 
-@deprecated("_get_nan_indices_by_column")
+@deprecated("get_nan_indices_by_column")
 def _get_nan(*args, **kwargs):
     return get_nan_indices_by_column(*args, **kwargs)
 
 
-@deprecated("_get_unrecorded_indices")
+@deprecated("get_unrecorded_indices")
 def _get_missing(*args, **kwargs):
     return get_unrecorded_indices(*args, **kwargs)
 
 
-@deprecated("_get_nan_indices_if_exists")
+@deprecated("get_nan_indices_if_exists")
 def _check_nan(*args, **kwargs):
     return get_nan_indices_if_exists(*args, **kwargs)
 
 
-@deprecated("_get_columns_with_nan_values")
+@deprecated("get_columns_with_nan_values")
 def _get_nan_columns(*args, **kwargs):
     return get_columns_with_nan_values(*args, **kwargs)
 
 
-@deprecated("_group_consecutive_elements")
+@deprecated("group_consecutive_elements")
 def _group_as_list(*args, **kwargs):
     return group_consecutive_elements(*args, **kwargs)
 
 
-@deprecated("_format_group_indices")
+@deprecated("format_group_indices")
 def _group_as_index(
     group_list, index=None, date_format="%Y%m%d", format_date="{}-{}"
 ):

--- a/hidrokit/contrib/taruma/hk84.py
+++ b/hidrokit/contrib/taruma/hk84.py
@@ -1,5 +1,32 @@
-"""manual:
-https://gist.github.com/taruma/cad07f29ffc025ba9e7801e752be3444
+"""
+hk84: summary_hourly
+This module provides functions for generating a summary of hourly data from a DataFrame.
+
+Functions:
+- summary_hourly(
+    dataframe, column, n_hours=24, 
+    text_date=None, return_as_dataframe=True, 
+    date_format="%Y-%m-%d", hour_format="%H:%M"): 
+        Generate a summary of hourly data from a DataFrame.
+
+    Args:
+        dataframe (pandas.DataFrame): The input DataFrame.
+        column (str): The name of the column containing the hourly data.
+        n_hours (int, optional): The number of hours to group together. Defaults to 24.
+        text_date (list, optional): The list of column names to include in the summary. 
+            Defaults to ['date', 'hour'].
+        return_as_dataframe (bool, optional): Whether to return the summary as a DataFrame. 
+            Defaults to True.
+        date_format (str, optional): The date format string. Defaults to '%Y-%m-%d'.
+        hour_format (str, optional): The hour format string. Defaults to '%H:%M'.
+
+    Returns:
+        pandas.DataFrame or dict: The summary of hourly data. 
+            If `return_as_dataframe` is True, a DataFrame is returned. 
+            Otherwise, a dictionary is returned.
+
+manual:
+    https://gist.github.com/taruma/cad07f29ffc025ba9e7801e752be3444
 """
 
 import pandas as pd

--- a/hidrokit/contrib/taruma/hk84.py
+++ b/hidrokit/contrib/taruma/hk84.py
@@ -2,14 +2,32 @@
 https://gist.github.com/taruma/cad07f29ffc025ba9e7801e752be3444
 """
 
-from hidrokit.contrib.taruma import hk73
 import pandas as pd
+from hidrokit.contrib.taruma import hk73
 
 
-def _time_grouped(
-    df, index_grouped, col, date_fmt='%Y-%m-%d', hour_fmt='%H:%M'
-):
-    """Return index_grouped as (list of date, list of hour)"""
+def _time_grouped(df, index_grouped, col, date_fmt="%Y-%m-%d", hour_fmt="%H:%M"):
+    """
+    Return index_grouped as (list of date, list of hour)
+
+    Parameters:
+    - df: pandas DataFrame
+        The DataFrame containing the data.
+    - index_grouped: list of tuples
+        The index groups to be processed.
+    - col: int or str
+        The column index or name to extract the date and hour values from.
+    - date_fmt: str, optional
+        The format string for the date values. Default is '%Y-%m-%d'.
+    - hour_fmt: str, optional
+        The format string for the hour values. Default is '%H:%M'.
+
+    Returns:
+    - date: list of lists
+        The list of date values for each index group.
+    - hour: list of lists
+        The list of hour values for each index group.
+    """
     date = []
     hour = []
     for item in index_grouped:
@@ -21,7 +39,16 @@ def _time_grouped(
 
 
 def _value_grouped(df, index_grouped, col):
-    """Return index_grouped as list of value list"""
+    """Return index_grouped as a list of value lists.
+
+    Args:
+        df (pandas.DataFrame): The input DataFrame.
+        index_grouped (list): The list of indices to group.
+        col (int): The column index to extract values from.
+
+    Returns:
+        list: A list of value lists corresponding to the grouped indices.
+    """
     value = []
     for item in index_grouped:
         value_val = df.iloc[item, col].to_list()
@@ -30,35 +57,70 @@ def _value_grouped(df, index_grouped, col):
 
 
 def _dict_grouped(date_list, hour_list, value_list, start=0):
-    """Join three list and return as dictionary"""
+    """
+    Join three lists and return as a dictionary.
+
+    Args:
+        date_list (list): List of dates.
+        hour_list (list): List of hours.
+        value_list (list): List of values.
+        start (int, optional): Starting index for the dictionary keys. Defaults to 0.
+
+    Returns:
+        dict: Dictionary with keys as indices and values as concatenated date, hour, and value.
+
+    """
     item_list = enumerate(zip(date_list, hour_list, value_list), start=start)
-    return {
-        i: date + hour + value for i, (date, hour, value) in item_list
-    }
+    return {i: date + hour + value for i, (date, hour, value) in item_list}
 
 
-def summary_hourly(df, column, n_hours=24,
-                   text_date=['date', 'hour'], as_df=True,
-                   date_fmt='%Y-%m-%d', hour_fmt='%H:%M'):
-    col = df.columns.get_loc(column)
-    nrows, _ = df.shape
+def summary_hourly(
+    dataframe,
+    column,
+    n_hours=24,
+    text_date=None,
+    return_as_dataframe=True,
+    date_format="%Y-%m-%d",
+    hour_format="%H:%M",
+): # pylint: disable=too-many-arguments,too-many-locals
+    """
+    Generate a summary of hourly data from a DataFrame.
+
+    Args:
+        df (pandas.DataFrame): The input DataFrame.
+        column (str): The name of the column containing the hourly data.
+        n_hours (int, optional): The number of hours to group together. Defaults to 24.
+        text_date (list, optional):
+            The list of column names to include in the summary. Defaults to ['date', 'hour'].
+        as_df (bool, optional): Whether to return the summary as a DataFrame. Defaults to True.
+        date_fmt (str, optional): The date format string. Defaults to '%Y-%m-%d'.
+        hour_fmt (str, optional): The hour format string. Defaults to '%H:%M'.
+
+    Returns:
+        pandas.DataFrame or dict:
+            The summary of hourly data. If `as_df` is True, a DataFrame is returned.
+            Otherwise, a dictionary is returned.
+    """
+    col = dataframe.columns.get_loc(column)
+    nrows, _ = dataframe.shape
     results = {}
+    text_date = ["date", "hour"] if text_date is None else text_date
 
     for i in range(0, nrows, n_hours):
-        sub_df = df.iloc[i:i + n_hours]
-        ix_array = hk73._get_index1D(~sub_df.iloc[:, col].isna().values)
-        ix_grouped = hk73._group_as_list(ix_array)
-        date, hour = _time_grouped(sub_df, ix_grouped,
-                                   col, date_fmt=date_fmt, hour_fmt=hour_fmt)
+        sub_df = dataframe.iloc[i : i + n_hours]
+        ix_array = hk73.get_missing_data_indices(~sub_df.iloc[:, col].isna().values)
+        ix_grouped = hk73.group_consecutive_elements(ix_array)
+        date, hour = _time_grouped(
+            sub_df, ix_grouped, col, date_fmt=date_format, hour_fmt=hour_format
+        )
         value = _value_grouped(sub_df, ix_grouped, col)
         each_hours = _dict_grouped(date, hour, value, start=i)
         results.update(each_hours)
 
-    if as_df:
+    if return_as_dataframe:
         columns_name = text_date + [i for i in range(1, n_hours + 1)]
         df_results = pd.DataFrame.from_dict(
-            results, orient='index', columns=columns_name
+            results, orient="index", columns=columns_name
         )
         return df_results
-    else:
-        return results
+    return results


### PR DESCRIPTION
### Ringkasan _Pull Request_

Refactor hk84

### Perbaikan/Fitur

close #243 

### Penggunaan

```
hk84: summary_hourly
This module provides functions for generating a summary of hourly data from a DataFrame.

Functions:
- summary_hourly(
    dataframe, column, n_hours=24, 
    text_date=None, return_as_dataframe=True, 
    date_format="%Y-%m-%d", hour_format="%H:%M"): 
        Generate a summary of hourly data from a DataFrame.

    Args:
        dataframe (pandas.DataFrame): The input DataFrame.
        column (str): The name of the column containing the hourly data.
        n_hours (int, optional): The number of hours to group together. Defaults to 24.
        text_date (list, optional): The list of column names to include in the summary. 
            Defaults to ['date', 'hour'].
        return_as_dataframe (bool, optional): Whether to return the summary as a DataFrame. 
            Defaults to True.
        date_format (str, optional): The date format string. Defaults to '%Y-%m-%d'.
        hour_format (str, optional): The hour format string. Defaults to '%H:%M'.

    Returns:
        pandas.DataFrame or dict: The summary of hourly data. 
            If `return_as_dataframe` is True, a DataFrame is returned. 
            Otherwise, a dictionary is returned.

manual:
    https://gist.github.com/taruma/cad07f29ffc025ba9e7801e752be3444
```
